### PR TITLE
fixing timestamp of screenrecorder 

### DIFF
--- a/selfdrive/ui/qt/screenrecorder/screenrecorder.cc
+++ b/selfdrive/ui/qt/screenrecorder/screenrecorder.cc
@@ -145,7 +145,7 @@ void ScreenRecoder::start(bool sound) {
 }
 
 void ScreenRecoder::encoding_thread_func() {
-
+  uint64_t start_time = nanos_since_boot() -1;
   while(recording && encoder) {
     QImage popImage;
     if(image_queue.pop_wait_for(popImage, std::chrono::milliseconds(10))) {
@@ -158,7 +158,7 @@ void ScreenRecoder::encoding_thread_func() {
             dst_width, dst_height,
             libyuv::kFilterLinear);
 
-      encoder->encode_frame_rgba(rgb_scale_buffer.get(), dst_width, dst_height, (uint64_t)nanos_since_boot());
+      encoder->encode_frame_rgba(rgb_scale_buffer.get(), dst_width, dst_height, ((uint64_t)nanos_since_boot() - start_time )));
     }
   }
 }


### PR DESCRIPTION
recored mp4 files has wrong timestmp ( --> since_boot )
if record start when drive after 1hr, records 1min,
file shows time stamp 1:00:00~1:01:00

fix timestamp to file timelength.

이온 브랜치 반영 가능 : O

만약 부팅이후 시간이 필요하다면,
녹화시작시점에 overlay 로 onroad.cc에 부팅 이후 시간을 따로 display하는게 어떨까 합니다.

기존 영상의 timestamp 예시. 15초 녹화파일에.. 48분으로 표기되어 동영상 플레이어에서 스크롤링하기가 제대로 동작하지 않음
![image](https://user-images.githubusercontent.com/4989674/174460642-6a205db1-8d31-491d-a072-b3ff026d2474.png)
